### PR TITLE
Refresh control on Posts.js

### DIFF
--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -25,7 +25,6 @@ export default class Settings extends Component {
   postMessage(text) {
     // Clear the text input field
     this._textInput.setNativeProps({ text: '' });
-
     // Post the message to the database
     fetch('http://127.0.0.1:8000/messages', {
       method: 'POST',
@@ -35,14 +34,12 @@ export default class Settings extends Component {
       },
       body: JSON.stringify({
         text: text,
-        latitude: this.props.position.latitude,
-        longitude: this.props.position.longitude,
+        latitude: this.props.location.latitude,
+        longitude: this.props.location.longitude,
         userAuth: this.props.userAuth
       })
     })
-    .then(() => {
-      this.props.updateMessages();
-    });
+    .then(() => { this.props.getMessages(); });
   }
 
   render() {

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -31,14 +31,9 @@ export default class Map extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      position: {
-        latitude: 0,
-        longitude: 0
-      }
     };
 
-    this.updatePosition = this.updatePosition.bind(this);
-    this.updateMessages = this.updateMessages.bind(this);
+    this.updateLocation = this.updateLocation.bind(this);
   }
 
   watchID: ?number = null;
@@ -46,38 +41,24 @@ export default class Map extends Component {
   componentDidMount(){
     this.getCurrentPosition();
     this.watchID = navigator.geolocation.watchPosition((position) => {
-      this.setState({
-        position: {
-          latitude: position.coords.latitude,
-          longitude: position.coords.longitude
-        }
-      }, () => this.updateMessages);
+      this.updateLocation(position);
     });
   }
 
   getCurrentPosition(){
     navigator.geolocation.getCurrentPosition(
       (position) => {
-        this.updatePosition(position);
+        this.updateLocation(position);
       },
       (error) => alert(JSON.stringify(error)),
       {enableHighAccuracy: true, timeout: 20000, maximumAge: 1000}
     );
   }
 
-  updatePosition(region) {
-    this.setState({
-      position: {
-        latitude: region.latitude,
-        longitude: region.longitude
-      }
-    });
-  }
-
-  updateMessages(){
-    const latitude = this.state.position.latitude;
-    const longitude = this.state.position.longitude;
-    this.props.getMessages({
+  updateLocation(position){
+    const latitude = position.latitude;
+    const longitude = position.longitude;
+    this.props.updateLocation({
       latitude: latitude,
       longitude: longitude
     });
@@ -88,8 +69,7 @@ export default class Map extends Component {
       <KeyboardAvoidingView behavior="padding" style={styles.container} automaticallyAdjustContentInsets={false}>
         <MapView id="map-view"
           style={styles.map}
-          onRegionChange={this.updatePosition}
-          onRegionChangeComplete={this.updateMessages}
+          onRegionChangeComplete={this.updateLocation}
           followsUserLocation={true}
           showsUserLocation={true}
           loadingEnabled={true}
@@ -118,8 +98,8 @@ export default class Map extends Component {
           )}
         </MapView>
         <Input
-          updateMessages={this.updateMessages}
-          position={this.state.position}
+          getMessages={this.props.getMessages}
+          location={this.props.location}
           userAuth={this.props.userAuth}
         />
       </KeyboardAvoidingView>

--- a/src/components/Posts.js
+++ b/src/components/Posts.js
@@ -2,7 +2,8 @@ import React, { Component } from 'react';
 import {
   StyleSheet,
   ListView,
-  ScrollView
+  ScrollView,
+  RefreshControl
 } from 'react-native';
 import PostRow from './PostRow';
 
@@ -22,8 +23,12 @@ export default class Posts extends Component {
     super(props);
 
     this.state = {
-      dataSource: ds.cloneWithRows(props.data)
+      dataSource: ds.cloneWithRows(props.data),
+      refreshing: false
     };
+
+    this.updateRefreshing = this.updateRefreshing.bind(this);
+    this.refreshMessages = this.refreshMessages.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -32,9 +37,27 @@ export default class Posts extends Component {
     });
   }
 
+  refreshMessages() {
+    this.setState({refreshing: true});
+    this.props.getMessages(this.updateRefreshing);
+  }
+
+  updateRefreshing() {
+    this.setState({
+      refreshing: false
+    });
+  }
+
   render() {
     return (
-      <ScrollView>
+      <ScrollView
+        refreshControl={
+          <RefreshControl
+            refreshing={this.state.refreshing}
+            onRefresh={this.refreshMessages}
+          />
+        }
+      >
         <ListView
           automaticallyAdjustContentInsets={false}
           contentContainerStyle={styles.container}

--- a/src/components/Posts.js
+++ b/src/components/Posts.js
@@ -3,7 +3,8 @@ import {
   StyleSheet,
   ListView,
   ScrollView,
-  RefreshControl
+  RefreshControl,
+  Text
 } from 'react-native';
 import PostRow from './PostRow';
 
@@ -11,6 +12,9 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     marginTop: 20
+  },
+  text: {
+    textAlign: 'center'
   }
 });
 
@@ -58,12 +62,20 @@ export default class Posts extends Component {
           />
         }
       >
+
+      { this.props.data.length > 0 ?
         <ListView
+          enableEmptySections={true}
           automaticallyAdjustContentInsets={false}
           contentContainerStyle={styles.container}
           dataSource={this.state.dataSource}
           renderRow={data => <PostRow message={data} />}
         />
+        :
+        <Text style={styles.text}>
+          There are no visible messages nearby.
+        </Text>
+      }
       </ScrollView>
     );
   }

--- a/src/index.ios.js
+++ b/src/index.ios.js
@@ -22,30 +22,42 @@ export default class Scribe extends Component {
 
     this.state = {
       data: [],
+      location: null,
       selectedTab: 'map',
       userAuth: null
     };
 
+    this.updateLocation = this.updateLocation.bind(this);
     this.getMessages = this.getMessages.bind(this);
     this.updateUser = this.updateUser.bind(this);
   }
 
-  getMessages(currentRegion) {
-    fetch(`http://127.0.0.1:8000/Messages?latitude=${currentRegion.latitude}&longitude=${currentRegion.longitude}`, {
-      method: 'GET'
-    })
-    .then(response => response.json())
-    .then((responseData) => {
-      this.setState({
-        data: responseData
-      });
-    });
+  getMessages(cb) {
+    if (this.state.location.latitude && this.state.location.longitude) {
+      fetch(`http://127.0.0.1:8000/Messages?latitude=${this.state.location.latitude}&longitude=${this.state.location.longitude}`, { method: 'GET'})
+        .then(response => response.json())
+        .then((responseData) => {
+          this.setState({
+            data: responseData
+          }, () => {
+            if (cb) {
+              cb();
+            }
+          });
+        });
+    }
   }
 
   updateUser(userAuth) {
     this.setState({
       userAuth: userAuth
     });
+  }
+
+  updateLocation(currentRegion) {
+    this.setState({
+      location: currentRegion
+    }, this.getMessages);
   }
 
   render() {
@@ -67,6 +79,8 @@ export default class Scribe extends Component {
           }}
         >
           <Map
+            location={this.state.location}
+            updateLocation={this.updateLocation}
             getMessages={this.getMessages}
             data={this.state.data}
             userAuth={this.state.userAuth}
@@ -84,6 +98,8 @@ export default class Scribe extends Component {
         >
           <Posts
             data={this.state.data}
+            location={this.state.location}
+            getMessages={this.getMessages}
           />
         </TabBarIOS.Item>
         <TabBarIOS.Item


### PR DESCRIPTION
- Allow users to drag down to refresh the list of posts (without having to go back to the maps view)
- index.ios.js now stores both 'data' (the posts received from the server) and 'location' (the current location received from the map)
- Posts view tells the user if there are no messages nearby